### PR TITLE
fix conversion error when importing viz

### DIFF
--- a/valis/viz.py
+++ b/valis/viz.py
@@ -159,7 +159,7 @@ def get_grid(shape, grid_spacing, thickness=1):
         if k % 2 == 0:
             col_add_idx += 1
 
-    return np.array(all_rows), np.array(all_cols)
+    return np.array(all_rows, dtype=np.int32), np.array(all_cols, dtype=np.int32)
 
 
 def jzazbz_cmap(luminosity=0.012, colorfulness=0.02, max_h=260):


### PR DESCRIPTION
TypingError: Failed in nopython mode pipeline (step: nopython frontend)
No conversion from UniTuple(array(int64, 1d, C) x 2) to UniTuple(array(int32, 1d, C) x 2) for '$372return_value.9', defined at None

File "..\PortableApps\anaconda3\envs\valis\lib\site-packages\valis\viz.py", line 167:
def get_grid(shape, grid_spacing, thickness=1):
    <source elided>
    #return np.array(all_rows, dtype=np.int32), np.array(all_cols, dtype=np.int32)
    return np.array(all_rows), np.array(all_cols)
    ^

During: typing of assignment at C:\PortableApps\anaconda3\envs\valis\lib\site-packages\valis\viz.py (167)

File "..\PortableApps\anaconda3\envs\valis\lib\site-packages\valis\viz.py", line 167:
def get_grid(shape, grid_spacing, thickness=1):
    <source elided>
    #return np.array(all_rows, dtype=np.int32), np.array(all_cols, dtype=np.int32)
    return np.array(all_rows), np.array(all_cols)
    ^