### PR TITLE
patched some of the code to work with saving uint16 IF .ome.tifs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,8 @@ cython_debug/
 
 # End of https://www.toptal.com/developers/gitignore/api/python,jupyternotebooks
 settings.json
+examples/expected_results/registration/ihc/processed/ihc_1.png
+examples/expected_results/registration/ihc/processed/ihc_1.png
+examples/expected_results/registration/ihc/processed/ihc_1.png
+*.png
+examples/expected_results/registration/ihc/processed/ihc_1.png

--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,5 @@ examples/expected_results/registration/ihc/processed/ihc_1.png
 examples/expected_results/registration/ihc/processed/ihc_1.png
 *.png
 examples/expected_results/registration/ihc/processed/ihc_1.png
+examples/register_HER2_IF.py
+*.png

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.10 (valis)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/valis.iml" filepath="$PROJECT_DIR$/.idea/valis.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/valis.iml
+++ b/.idea/valis.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/valis/serial_rigid.py
+++ b/valis/serial_rigid.py
@@ -634,7 +634,26 @@ class SerialRigidRegistrar(object):
 
         shared_pts, nf_prev_idx, nf_next_idx  = np.intersect1d(xy_to_prev_idx, xy_to_next_idx, return_indices=True)
 
-        assert np.all(xy_to_prev[nf_prev_idx, :] == xy_to_next[nf_next_idx, :])
+        # assertion error, why does this not always equal? rounding errors in warp_tools.index2d_to_1d()?
+        # assert np.all(xy_to_prev[nf_prev_idx, :] == xy_to_next[nf_next_idx, :])
+
+        # should you remove the indexes that don't match...?
+        # for testing this code...
+        # prev_inter = xy_to_prev[nf_prev_idx, :][0:5]
+        # next_inter = xy_to_next[nf_next_idx, :][0:5]
+        # prev_inter[3,:] = 5
+        # prev_inter[4, 0] = 5
+        # prev_inter[diff]
+        # next_inter[diff]
+        # diff = np.where(prev_inter != next_inter)
+
+        #trying to remove diff features if they are different... (possible due to some very rare rounding errors?)
+        diff = np.where(xy_to_prev[nf_prev_idx, :] != xy_to_next[nf_next_idx, :])
+        if diff[0].any():
+            # print("removing diffs!")
+            diff = list(np.unique(diff[0]))
+            nf_prev_idx = np.delete(nf_prev_idx, diff)
+            nf_next_idx = np.delete(nf_next_idx, diff)
 
         return nf_prev_idx, nf_next_idx
 

--- a/valis/slide_io.py
+++ b/valis/slide_io.py
@@ -837,7 +837,7 @@ class BioFormatsSlideReader(SlideReader):
 
             valtils.print_warning(msg, warning_type=None, rgb=valtils.Fore.GREEN)
 
-        self._seris = series
+        self._series = series
         self.series = series
 
     def _set_series(self, series):

--- a/valis/slide_tools.py
+++ b/valis/slide_tools.py
@@ -75,7 +75,7 @@ def vips2numpy(vi):
     return img
 
 
-def numpy2vips(a):
+def numpy2vips(a, pyvips_interpretation=None):
     """
 
     """
@@ -89,6 +89,9 @@ def numpy2vips(a):
     linear = a.reshape(width * height * bands)
     vi = pyvips.Image.new_from_memory(linear.data, width, height, bands,
                                       NUMPY_FORMAT_VIPS_DTYPE[str(a.dtype)])
+    # maybe a try catch is better here, but could be slower performance-wise
+    if pyvips_interpretation is not None:
+        vi = vi.copy(interpretation=pyvips_interpretation)
     return vi
 
 

--- a/valis/viz.py
+++ b/valis/viz.py
@@ -159,7 +159,7 @@ def get_grid(shape, grid_spacing, thickness=1):
         if k % 2 == 0:
             col_add_idx += 1
 
-    return np.array(all_rows), np.array(all_cols)
+    return np.array(all_rows, dtype=np.int32), np.array(all_cols, dtype=np.int32)
 
 
 def jzazbz_cmap(luminosity=0.012, colorfulness=0.02, max_h=260):

--- a/valis/viz.py
+++ b/valis/viz.py
@@ -10,10 +10,17 @@ import numpy as np
 import numba as nb
 from . import warp_tools
 import cv2
+import platform
 # JzAzBz #
 DXDY_CSPACE = "JzAzBz"
 DXDY_CRANGE = (0, 0.025)
 DXDY_LRANGE = (0.004, 0.015)
+
+if platform.system() == 'Windows' or platform.system() == 'Darwin':
+    uniTupleDtype = np.int32
+else:
+    uniTupleDtype = np.int64
+
 
 # CAM16-UCS #
 # DXDY_CSPACE = "CAM16UCS"
@@ -159,7 +166,7 @@ def get_grid(shape, grid_spacing, thickness=1):
         if k % 2 == 0:
             col_add_idx += 1
 
-    return np.array(all_rows, dtype=np.int32), np.array(all_cols, dtype=np.int32)
+    return np.array(all_rows, dtype=uniTupleDtype), np.array(all_cols, dtype=uniTupleDtype)
 
 
 def jzazbz_cmap(luminosity=0.012, colorfulness=0.02, max_h=260):


### PR DESCRIPTION
In addition to crudely patching the platform errors with the numba UniTuple conversion, I noticed that the current code would default to saving my uint16 ome.tif files to uint8 after warping and saving slides. 

I found that this was due to the BioFormatsSlideReader tiling step in line 870 of slide_io.py, where the uint16 datatype would be converted to a ubyte/uchar. So I commented that out, but maybe there is a better way to handle this to preserve the input datatypes?

I also added some code to the BioFormatsSlideReader to specify the pyvips interpretation in the metadata based on the input image (not sure if this is necessary), and in the VipsSlideReader to specify that the n_channels was at least the amount of channel_names for toilet roll images. This was giving me trouble when using the VipsSlideReader for interpreting the channel names in the process_imgs() code, so I patched it. 

I also found that I would rarely get an assertion error for one of my set of images in serial_rigid.py get_neighbor_matches_idx(). 

`assert np.all(xy_to_prev[nf_prev_idx, :] == xy_to_next[nf_next_idx, :])`

This was surprisingly not true for one of my image pairs, so instead I opted to just remove any indexes that differed.

Not sure if it's the best practice for all cases, but thought I'd share how I got the code to work with these uint16 .ome.tif IF images.

Thank you again for this work, this repo is awesome!

Cheers,
Jack

