### PR TITLE
``None`` option for norm_method argument

### DIFF
--- a/valis/registration.py
+++ b/valis/registration.py
@@ -1790,9 +1790,10 @@ class Valis(object):
 
         norm_method : str
             Name of method used to normalize the processed images. Options
-            are "histo_match" for histogram matching, "img_stats" for normalizing by
-            image statistics. See preprocessing.match_histograms
-            and preprocessing.norm_khan for details.
+            are None when normalization is not desired, "histo_match" for 
+            histogram matching and "img_stats" for normalizing by image statistics. 
+            See preprocessing.match_histograms and preprocessing.norm_khan 
+            for details.
 
         _non_rigid_bbox : list
             Bounding box of area in which non-rigid registration was conducted
@@ -3051,8 +3052,10 @@ class Valis(object):
                 processed_img[np_mask==0] = 0
 
                 # Normalize images using stats collected for rigid registration #
-                warped_img = preprocessing.norm_img_stats(processed_img, self.target_processing_stats, mask=slide_mask)
-                warped_img = exposure.rescale_intensity(warped_img, out_range=(0, 255)).astype(np.uint8)
+                if hasattr(self, "target_processing_stats"):
+                    processed_img = preprocessing.norm_img_stats(processed_img, self.target_processing_stats, mask=slide_mask)
+                
+                warped_img = exposure.rescale_intensity(processed_img, out_range=(0, 255)).astype(np.uint8)
 
             else:
                 if not warp_full_img:


### PR DESCRIPTION
Hi @cdgatenbee,

I would like to suggest a small modification in addition to the HEDeconvolution cls I submitted for your review. Since this cls already normalizes the input images, I propose the addition of an option to skip the normalization step in the pipeline.

Best,
Arthur