### PR TITLE
adding sched_getaffinity when available to determine number of procs

### DIFF
--- a/examples/acrobat_2023/valis/non_rigid_registrars.py
+++ b/examples/acrobat_2023/valis/non_rigid_registrars.py
@@ -18,6 +18,8 @@ from . import viz
 from . import warp_tools
 from . import preprocessing
 
+from .valtils import get_ncpus_available
+
 NR_CLS_KEY = "non_rigid_registrar_cls"
 NR_PROCESSING_KW_KEY = "processing_kwargs"
 NR_PROCESSING_CLASS_KEY = "processing_cls"
@@ -1359,7 +1361,7 @@ class NonRigidTileRegistrar(object):
 
         print("======== Registering tiles\n")
         lock = multiprocessing.Lock()
-        n_cpu = multiprocessing.cpu_count() - 1
+        n_cpu = get_ncpus_available() - 1
         self.pbar = tqdm(total=self.n_tiles)
         with parallel_backend("threading", n_jobs=n_cpu):
             Parallel()(delayed(self.reg_tile)(i, lock) for i in range(self.n_tiles))

--- a/examples/acrobat_2023/valis/serial_rigid.py
+++ b/examples/acrobat_2023/valis/serial_rigid.py
@@ -22,6 +22,7 @@ from . import valtils
 from . import warp_tools
 from .feature_detectors import VggFD
 from .feature_matcher import Matcher, convert_distance_to_similarity, GMS_NAME
+from .valtils import get_ncpus_available
 
 def get_image_files(img_dir, imgs_ordered=False):
     """Get images filenames in img_dir
@@ -564,7 +565,7 @@ class SerialRigidRegistrar(object):
             if qt_emitter is not None:
                 qt_emitter.emit(1)
 
-        n_cpu = multiprocessing.cpu_count() - 1
+        n_cpu = get_ncpus_available() - 1
         with parallel_backend("threading", n_jobs=n_cpu):
             Parallel()(delayed(match_adj_img_obj)(i) for i in range(self.size))
 
@@ -629,7 +630,7 @@ class SerialRigidRegistrar(object):
                 if qt_emitter is not None:
                     qt_emitter.emit(1)
 
-        n_cpu = multiprocessing.cpu_count() - 1
+        n_cpu = get_ncpus_available() - 1
         with parallel_backend("threading", n_jobs=n_cpu):
             Parallel()(delayed(match_img_obj)(i) for i in range(self.size))
 

--- a/examples/acrobat_2023/valis/slide_io.py
+++ b/examples/acrobat_2023/valis/slide_io.py
@@ -26,6 +26,8 @@ import jpype
 from aicspylibczi import CziFile
 from tqdm import tqdm
 import scyjava
+from .valtils import get_ncpus_available
+
 
 
 from . import valtils
@@ -901,7 +903,7 @@ class BioFormatsSlideReader(SlideReader):
             tile_array[idx] = slide_tools.numpy2vips(tile, self.metadata.pyvips_interpretation)
 
 
-        n_cpu = multiprocessing.cpu_count() - 1
+        n_cpu = get_ncpus_available() - 1
         with parallel_backend("threading", n_jobs=n_cpu):
             Parallel()(delayed(tile2vips_threaded)(i) for i in tqdm(range(n_tiles)))
 

--- a/examples/acrobat_2023/valis/warp_tools.py
+++ b/examples/acrobat_2023/valis/warp_tools.py
@@ -23,6 +23,8 @@ import os
 import re
 from copy import deepcopy
 from . import valtils
+from .valtils import get_ncpus_available
+
 
 pyvips.cache_set_max(0)
 
@@ -2877,7 +2879,7 @@ def get_overlapping_poly(mesh_poly_coords):
             else:
                 poly_diffs.append(diff.buffer(buffer_v))
 
-    n_cpu = multiprocessing.cpu_count() - 1
+    n_cpu = get_ncpus_available() - 1
     with parallel_backend("threading", n_jobs=n_cpu):
         Parallel()(delayed(clip_poly)(i) for i in tqdm.tqdm(range(n_poly)))
 

--- a/valis/micro_rigid_registrar.py
+++ b/valis/micro_rigid_registrar.py
@@ -9,6 +9,8 @@ from . import feature_detectors
 from . import preprocessing
 from . import warp_tools
 from . import valtils
+from .valtils import get_ncpus_available
+
 from pqdm.threads import pqdm
 
 ROI_MASK = "mask"
@@ -292,7 +294,7 @@ class MicroRigidRegistrar(object):
             high_rez_fixed_match_xy_list[bbox_id] = matched_fixed_xy
 
         print(f"Aligning {moving_slide.name} to {fixed_slide.name}. ROI width, height is {reg_bbox[2:]} pixels")
-        n_cpu = multiprocessing.cpu_count() - 1
+        n_cpu = get_ncpus_available() - 1
 
         with suppress(UserWarning):
             # Avoid printing warnings that not enough matches were found, which can happen frequently with this

--- a/valis/non_rigid_registrars.py
+++ b/valis/non_rigid_registrars.py
@@ -1372,7 +1372,7 @@ class NonRigidTileRegistrar(object):
 
         print("======== Registering tiles\n")
 
-        n_cpu = multiprocessing.cpu_count() - 1
+        n_cpu = get_ncpus_available() - 1
 
         lock = multiprocessing.Lock()
         args = [{"tile_idx":i, "lock":lock} for i in range(self.n_tiles)]

--- a/valis/serial_rigid.py
+++ b/valis/serial_rigid.py
@@ -22,6 +22,8 @@ from . import warp_tools
 from . import slide_tools
 from .feature_detectors import VggFD
 from .feature_matcher import Matcher, convert_distance_to_similarity, GMS_NAME
+from .valtils import get_ncpus_available
+
 
 DENOISE_MSG = "Denoising images"
 FEATURE_MSG = "Detecting features"
@@ -570,7 +572,7 @@ class SerialRigidRegistrar(object):
             if qt_emitter is not None:
                 qt_emitter.emit(1)
 
-        n_cpu = multiprocessing.cpu_count() - 1
+        n_cpu = get_ncpus_available() - 1
         res = pqdm(range(self.size), match_adj_img_obj, n_jobs=n_cpu, desc=MATCHING_MSG, unit="image", leave=None)
 
         # with parallel_backend("threading", n_jobs=n_cpu):
@@ -632,7 +634,7 @@ class SerialRigidRegistrar(object):
                 if qt_emitter is not None:
                     qt_emitter.emit(1)
 
-        n_cpu = multiprocessing.cpu_count() - 1
+        n_cpu = get_ncpus_available() - 1
         res = pqdm(range(self.size), match_img_obj, n_jobs=n_cpu, desc=MATCHING_MSG, unit="image", leave=None)
 
         # with parallel_backend("threading", n_jobs=n_cpu):

--- a/valis/slide_io.py
+++ b/valis/slide_io.py
@@ -32,6 +32,8 @@ from colorama import Fore
 from . import valtils
 from . import slide_tools
 from . import warp_tools
+from .valtils import get_ncpus_available
+
 
 pyvips.cache_set_max(0)
 
@@ -1150,7 +1152,7 @@ class BioFormatsSlideReader(SlideReader):
             tile_array[idx] = slide_tools.numpy2vips(tile, self.metadata.pyvips_interpretation)
 
 
-        n_cpu = multiprocessing.cpu_count() - 1
+        n_cpu = get_ncpus_available() - 1
         res = pqdm(range(n_tiles), tile2vips_threaded, n_jobs=n_cpu, unit="tiles", leave=None)
 
         return tile_array

--- a/valis/valtils.py
+++ b/valis/valtils.py
@@ -1,5 +1,6 @@
 import re
 import os
+import multiprocessing
 from colorama import init as color_init
 from colorama import Fore, Style
 import functools
@@ -184,4 +185,15 @@ def hex_to_rgb(value):
     value = value.lstrip('#')
     lv = len(value)
     return tuple(int(value[i:i + lv // 3], 16) for i in range(0, lv, lv // 3))
+
+
+def get_ncpus_available():
+    ncpus = 2 ## returning 2 by default as code assumes ncpus > 1 (or that packages gracefully handle scheduling 0 jobs/threads)
+
+    if hasattr(os, "sched_getaffinity"):
+        ncpus = len(os.sched_getaffinity(0))
+    elif hasattr(multiprocessing, "cpu_count"):
+        ncpus = multiprocessing.cpu_count()
+
+    return int(ncpus)
 

--- a/valis/warp_tools.py
+++ b/valis/warp_tools.py
@@ -24,6 +24,8 @@ import re
 
 from copy import deepcopy
 from . import valtils
+from .valtils import get_ncpus_available
+
 
 pyvips.cache_set_max(0)
 
@@ -2884,7 +2886,7 @@ def get_overlapping_poly(mesh_poly_coords):
             else:
                 poly_diffs.append(diff.buffer(buffer_v))
 
-    n_cpu = multiprocessing.cpu_count() - 1
+    n_cpu = get_ncpus_available() - 1
     res = pqdm(range(n_poly), clip_poly, n_jobs=n_cpu, unit="image", leave=None)
 
     return overlapping_poly_list, poly_diffs


### PR DESCRIPTION
Pull request regarding #114 .

The main part I am not confident about is what the default return should be (https://github.com/p-smirnov/valis/blob/1416c233ff212b5cf67de4a96753f9989471ec51/valis/valtils.py#L191) if no information about cpu count is available (not even sure if there are systems where `multiprocessing.cpu_count` does not exist). 

It seems that in most places in the code, the assumption is that ncpu > 1, and 1 cpu is kept free for system responsiveness/for the parent python process. I am not sure how the different multiprocessing functions would handle nthread=0, so I think a default value of 2 makes sense to be on the safe side. 