### PR TITLE
fix #176, librsvg-2.so.2 not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,7 +130,8 @@ RUN  apt-get remove -y wget build-essential ninja-build && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
   rm -rf /usr/local/lib/python*
 
-
+RUN apt-get update
+RUN apt-get install -y librsvg2-dev
 
 
 


### PR DESCRIPTION
Hi, this problem https://github.com/MathOnco/valis/issues/176 was fixed.

![bugfix-valis-176](https://github.com/user-attachments/assets/64d077ed-1d0c-416f-9fc4-bd81df213373)
