### PR TITLE
fix: only cleanup non_rigid_reg_kwargs if it is defined

### DIFF
--- a/valis/registration.py
+++ b/valis/registration.py
@@ -4788,7 +4788,8 @@ class Valis(object):
         self.rigid_reg_kwargs[AFFINE_OPTIMIZER_KEY] = None
         self.rigid_reg_kwargs[MATCHER_KEY] = None
         self.rigid_reg_kwargs[MATCHER_FOR_SORTING_KEY] = None
-        self.non_rigid_reg_kwargs[NON_RIGID_REG_CLASS_KEY] = None
+        if hasattr(self, "non_rigid_reg_kwargs"):
+            self.non_rigid_reg_kwargs[NON_RIGID_REG_CLASS_KEY] = None
         self.non_rigid_registrar_cls = None
         self.rigid_registrar = None
         self.micro_rigid_registrar_cls = None


### PR DESCRIPTION
This PR adds a verification in the cleanup method to avoid accessing `non_rigid_reg_kwargs` if it is not defined (in the case of a rigid only registration). This fixes #218. The attribute `rigid_reg_kwargs` is defined in all cases, and no other attribute is accessed in this method, so no additional checks are added.